### PR TITLE
Update README.rst with pip install instruction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,16 @@ The ``*`` can also be used for hash types::
 The expression: ``foo.*.name`` will return ["one", "two"].
 
 
+Installation
+============
+
+Install jmespath from pypi with
+
+.. code:: bash
+
+    pip install jmespath
+    
+
 API
 ===
 


### PR DESCRIPTION
This might seem obvious, but sometimes the pypi package name does not match with the github package name, which makes it important to be explicit